### PR TITLE
Update to linq2db 5.4.1

### DIFF
--- a/src/LinqToDB.Identity/Extensions.cs
+++ b/src/LinqToDB.Identity/Extensions.cs
@@ -56,7 +56,7 @@ namespace LinqToDB.Identity
 						Expression.Convert(Expression.PropertyOrField(p, column.MemberName), typeof(object)),
 						p);
 
-				var val = column.MemberAccessor.Getter(obj);
+				var val = column.MemberAccessor.GetValue(obj);
 				query = query.Set(expr, val);
 			}
 

--- a/src/LinqToDB.Identity/LinqToDB.Identity.csproj
+++ b/src/LinqToDB.Identity/LinqToDB.Identity.csproj
@@ -2,13 +2,13 @@
 
 	<PropertyGroup>
 		<Description>ASP.NET Core Identity provider that uses LinqToDB.</Description>
-		<VersionPrefix>3.5.0</VersionPrefix>
-		<Version>3.5.0</Version>
-		<PackageVersion>3.5.0</PackageVersion>
+		<VersionPrefix>4.0.0</VersionPrefix>
+		<Version>4.0.0</Version>
+		<PackageVersion>4.0.0</PackageVersion>
 		
 		<Authors>Ilya Chudin</Authors>
 		
-		<TargetFrameworks>net461;netstandard2.0;netcoreapp2.1</TargetFrameworks>
+		<TargetFrameworks>netstandard2.0</TargetFrameworks>
 		<AutoGenerateBindingRedirects>true</AutoGenerateBindingRedirects>
 
 		<TreatWarningsAsErrors>true</TreatWarningsAsErrors>
@@ -41,14 +41,11 @@
 	</ItemGroup>
 
 	<ItemGroup>
-		<PackageReference Include="linq2db" Version="5.0.0" />
+		<PackageReference Include="linq2db" Version="5.4.1" />
 	
-		<PackageReference Include="Microsoft.AspNetCore.Identity" Version="2.1.2" />
-		<PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="2.1.1" />
-		<PackageReference Include="Microsoft.Extensions.Identity.Stores" Version="2.1.2" />
+		<PackageReference Include="Microsoft.AspNetCore.Identity" Version="2.1.39" />
+		<PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="6.0.1" />
+		<PackageReference Include="Microsoft.Extensions.Identity.Stores" Version="6.0.31" />
 	</ItemGroup>
 
-	<PropertyGroup Condition="'$(TargetFramework)'=='netstandard2.0' OR '$(TargetFramework)'=='netcoreapp2.1'">
-		<DefineConstants>$(DefineConstants);NETSTANDARD2_0</DefineConstants>
-	</PropertyGroup>
 </Project>


### PR DESCRIPTION
Fix #25

- rebuild against linq2db 5.4.1
- replace old TFMs with ns2.0